### PR TITLE
ts: just use `TokenQuoteWithRouterFee`

### DIFF
--- a/ts/sdk/src/routers/mod.rs
+++ b/ts/sdk/src/routers/mod.rs
@@ -217,12 +217,19 @@ pub fn update(
     Ok(())
 }
 
+// need to use a simple newtype here instead of type alias
+// otherwise wasm_bindgen shits itself with missing generics
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi, large_number_types_as_bigints)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenQuoteWithRouterFee(WithRouterFee<TokenQuote>);
+
 /// Requires `update()` to be called before calling this function
 #[wasm_bindgen(js_name = getDepositSolQuote)]
 pub fn get_deposit_sol_quote(
     this: &SanctumRouterHandle,
     params: QuoteParams,
-) -> Option<TokenQuote> {
+) -> Option<TokenQuoteWithRouterFee> {
     match params.output_mint.0 {
         sanctum_marinade_liquid_staking_core::MSOL_MINT_ADDR => this
             .0
@@ -237,6 +244,7 @@ pub fn get_deposit_sol_quote(
             .to_deposit_sol_router()
             .get_deposit_sol_quote(params.amount),
     }
+    .map(|q| TokenQuoteWithRouterFee(WithRouterFee::zero(q)))
 }
 
 /// Requires `update()` to be called before calling this function
@@ -291,13 +299,6 @@ pub fn get_deposit_sol_ix(
 
     Ok(ix)
 }
-
-// need to use a simple newtype here instead of type alias
-// otherwise wasm_bindgen shits itself with missing generics
-#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi, large_number_types_as_bigints)]
-#[serde(rename_all = "camelCase")]
-pub struct TokenQuoteWithRouterFee(WithRouterFee<TokenQuote>);
 
 /// Requires `update()` to be called before calling this function
 #[wasm_bindgen(js_name = getWithdrawSolQuote)]

--- a/ts/tests/utils/test/swap.ts
+++ b/ts/tests/utils/test/swap.ts
@@ -23,15 +23,9 @@ import { tokenAccBalance } from "../token";
 import { ixToSimTx } from "../tx";
 import { txSimParams } from "./common";
 
-function discmQuote(
-  quote: TokenQuote | TokenQuoteWithRouterFee
-): quote is TokenQuote {
-  return (quote as any).routerFee == null;
-}
-
 export async function simTokenSwapAssertQuoteMatches(
   rpc: Rpc<SolanaRpcApi>,
-  quote: TokenQuote | TokenQuoteWithRouterFee,
+  { quote: { inAmount, outAmount }, routerFee }: TokenQuoteWithRouterFee,
   {
     amount,
     sourceTokenAccount,
@@ -41,10 +35,6 @@ export async function simTokenSwapAssertQuoteMatches(
   }: SwapParams,
   ix: Instruction
 ) {
-  const [{ inAmount, outAmount }, routerFee] = discmQuote(quote)
-    ? [quote, 0n]
-    : [quote.quote, quote.routerFee];
-
   expect(inAmount).toStrictEqual(amount);
 
   // `addresses` layout:


### PR DESCRIPTION
Simplify the interface for users by just using the same `TokenQuoteWithRouterFee` with `routerFee=0` even for `StakeWrappedSol` so that users dont need to convert between types.