### PR TITLE
LST-157 TS: add bridge stake account info to quotePrefundSwapViaStake return

### DIFF
--- a/ts/sdk/README.md
+++ b/ts/sdk/README.md
@@ -103,6 +103,7 @@ const {
       out,
       inpFee,
       outFee,
+      bridge,
     },
   },
 } = quotePrefundSwapViaStake(sanctumRouter, {
@@ -132,6 +133,10 @@ const ixUncasted = prefundSwapViaStakeIx(sanctumRouter, {
   signerOut: outTokenAcc,
   signer,
   bridgeStakeSeed,
+
+  // optional, this fn runs faster if provided with the
+  // bridge stake account's delegated voter that was found beforehand
+  bridgeVote: bridge.vote,
 });
 // return type is compatible with kit,
 // but needs to be casted explicitly

--- a/ts/sdk/src/router/swap_via_stake.rs
+++ b/ts/sdk/src/router/swap_via_stake.rs
@@ -3,8 +3,8 @@ use sanctum_marinade_liquid_staking_core::MSOL_MINT_ADDR;
 use sanctum_router_core::{
     quote_prefund_swap_via_stake as core_quote, DepositStakeQuote, DepositStakeSufAccs, Prefund,
     PrefundSwapViaStakeIxData, PrefundSwapViaStakePrefixAccsBuilder, SplWithdrawStakeValQuoter,
-    WithRouterFee, WithdrawStakeQuote, WithdrawStakeSufAccs, NATIVE_MINT, PREFUNDER,
-    PREFUND_SWAP_VIA_STAKE_PREFIX_ACCS_LEN, PREFUND_SWAP_VIA_STAKE_PREFIX_IS_SIGNER,
+    StakeAccountLamports, WithRouterFee, WithdrawStakeQuote, WithdrawStakeSufAccs, NATIVE_MINT,
+    PREFUNDER, PREFUND_SWAP_VIA_STAKE_PREFIX_ACCS_LEN, PREFUND_SWAP_VIA_STAKE_PREFIX_IS_SIGNER,
     PREFUND_SWAP_VIA_STAKE_PREFIX_IS_WRITER_NON_WSOL_OUT,
     PREFUND_SWAP_VIA_STAKE_PREFIX_IS_WRITER_WSOL_OUT, SANCTUM_ROUTER_PROGRAM, STAKE_PROGRAM,
     SYSTEM_PROGRAM, SYSVAR_CLOCK,
@@ -28,6 +28,18 @@ use crate::{
     router::{token_pair::TokenQuoteParams, SanctumRouter, SanctumRouterHandle},
 };
 
+/// Select parameters of an active stake account
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Tsify)]
+#[serde(rename_all = "camelCase")]
+#[tsify(into_wasm_abi, from_wasm_abi, large_number_types_as_bigints)]
+pub struct ActiveStakeParams {
+    /// Vote account of the validator this stake account is delegated to
+    pub vote: B58PK,
+
+    /// This stake account's lamport balances
+    pub lamports: StakeAccountLamports,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Tsify)]
 #[serde(rename_all = "camelCase")]
 #[tsify(into_wasm_abi, from_wasm_abi, large_number_types_as_bigints)]
@@ -43,6 +55,9 @@ pub struct SwapViaStakeQuote {
 
     /// Fee charged on deposit stake leg, in terms of output tokens
     pub out_fee: u64,
+
+    /// Info about the bridge stake account used
+    pub bridge: ActiveStakeParams,
 }
 
 // need to use a simple newtype here instead of type alias
@@ -81,9 +96,17 @@ fn map_quote(
     dsq: DepositStakeQuote,
 ) -> PrefundSwapViaStakeQuoteWithRouterFee {
     let WithRouterFee {
-        quote: DepositStakeQuote {
-            out, fee: out_fee, ..
-        },
+        quote:
+            DepositStakeQuote {
+                inp:
+                    sanctum_router_core::ActiveStakeParams {
+                        vote: bridge_vote,
+                        lamports: bridge_lamports,
+                    },
+                out,
+                fee: out_fee,
+                ..
+            },
         router_fee,
     } = if *out_mint != sanctum_router_core::NATIVE_MINT {
         dsq.with_router_fee()
@@ -97,6 +120,10 @@ fn map_quote(
                 out,
                 inp_fee,
                 out_fee,
+                bridge: ActiveStakeParams {
+                    vote: B58PK::new(bridge_vote),
+                    lamports: bridge_lamports,
+                },
             },
             router_fee,
         },
@@ -188,6 +215,11 @@ pub struct SwapViaStakeSwapParams {
 
     /// Signing authority of `self.signer_inp`; user making the swap.
     pub signer: B58PK,
+
+    /// Obtained from {@link SwapViaStakeQuote}.bridge.vote.
+    /// Optional, makes instruction formation faster if provided
+    #[tsify(optional)]
+    pub bridge_vote: Option<B58PK>,
 }
 
 /// Requires `update()` to be called before calling this function
@@ -203,9 +235,14 @@ pub fn prefund_swap_via_stake_ix(
     let out_mint = params.out.0;
 
     let (prefix_metas, data, bridge_stake) = prefund_swap_via_stake_prefix(&params)?;
-    let (_wsq, dsq) =
-        quote_prefund_swap_via_stake_inner(&this.0, params.amt, &inp_mint, &out_mint)?;
-    let vote = dsq.inp.vote;
+    let vote = match params.bridge_vote {
+        Some(Bs58Array(vote)) => vote,
+        None => {
+            let (_wsq, dsq) =
+                quote_prefund_swap_via_stake_inner(&this.0, params.amt, &inp_mint, &out_mint)?;
+            dsq.inp.vote
+        }
+    };
 
     let mut metas = Vec::from(prefix_metas);
 

--- a/ts/sdk/src/router/swap_via_stake.rs
+++ b/ts/sdk/src/router/swap_via_stake.rs
@@ -56,7 +56,14 @@ pub struct SwapViaStakeQuote {
     /// Fee charged on deposit stake leg, in terms of output tokens
     pub out_fee: u64,
 
-    /// Info about the bridge stake account used
+    /// Info about the bridge stake account used.
+    ///
+    /// This is the state of the stake account right before it is deposited
+    /// to mint the out LST, not right after it is withdrawn from redeeming the inp LST.
+    ///
+    /// This means for PrefundSwapViaStake's case, the `StakeAccountLamports` of the
+    /// stake account that was withdrawn from redeeming the inp LST `= this.lamports
+    /// + prefund fee in active stake`
     pub bridge: ActiveStakeParams,
 }
 
@@ -101,7 +108,7 @@ fn map_quote(
                 inp:
                     sanctum_router_core::ActiveStakeParams {
                         vote: bridge_vote,
-                        lamports: bridge_lamports,
+                        lamports: bridge_lamports_bef_deposit,
                     },
                 out,
                 fee: out_fee,
@@ -122,7 +129,7 @@ fn map_quote(
                 out_fee,
                 bridge: ActiveStakeParams {
                     vote: B58PK::new(bridge_vote),
-                    lamports: bridge_lamports,
+                    lamports: bridge_lamports_bef_deposit,
                 },
             },
             router_fee,

--- a/ts/tests/test/lido.test.ts
+++ b/ts/tests/test/lido.test.ts
@@ -24,6 +24,19 @@ describe("Lido Test", async () => {
     });
   });
 
+  it("lido-prefund-swap-via-stake-into-reserve-use-bridge-vote", async () => {
+    await prefundSwapViaStakeFixturesTest(
+      1_000_000_000n,
+      {
+        inp: STSOL_TOKEN_ACC_NAME,
+        out: "signer-wsol-token",
+      },
+      {
+        useBridgeVote: true,
+      }
+    );
+  });
+
   it("lido-prefund-swap-via-stake-into-marinade", async () => {
     await prefundSwapViaStakeFixturesTest(1_000_000_000n, {
       inp: STSOL_TOKEN_ACC_NAME,
@@ -31,10 +44,34 @@ describe("Lido Test", async () => {
     });
   });
 
+  it("lido-prefund-swap-via-stake-into-marinade-use-bridge-vote", async () => {
+    await prefundSwapViaStakeFixturesTest(
+      1_000_000_000n,
+      {
+        inp: STSOL_TOKEN_ACC_NAME,
+        out: "signer-msol-token",
+      },
+      {
+        useBridgeVote: true,
+      }
+    );
+  });
+
   it("lido-prefund-swap-via-stake-into-spl-bsol", async () => {
     await prefundSwapViaStakeFixturesTest(1_000_000_000n, {
       inp: STSOL_TOKEN_ACC_NAME,
       out: "signer-bsol-token",
     });
+  });
+
+  it("lido-prefund-swap-via-stake-into-spl-bsol-use-bridge-vote", async () => {
+    await prefundSwapViaStakeFixturesTest(
+      1_000_000_000n,
+      {
+        inp: STSOL_TOKEN_ACC_NAME,
+        out: "signer-bsol-token",
+      },
+      { useBridgeVote: true }
+    );
   });
 });

--- a/ts/tests/test/spl.test.ts
+++ b/ts/tests/test/spl.test.ts
@@ -51,6 +51,17 @@ describe("SPL Test", async () => {
     });
   });
 
+  it("spl-picosol-prefund-swap-via-stake-into-reserve-use-bridge-vote", async () => {
+    await prefundSwapViaStakeFixturesTest(
+      1_000_000_000n,
+      {
+        inp: PICOSOL_TOKEN_ACC_NAME,
+        out: "signer-wsol-token",
+      },
+      { useBridgeVote: true }
+    );
+  });
+
   it("spl-picosol-prefund-swap-via-stake-into-marinade", async () => {
     await prefundSwapViaStakeFixturesTest(1_000_000_000n, {
       inp: PICOSOL_TOKEN_ACC_NAME,
@@ -58,10 +69,32 @@ describe("SPL Test", async () => {
     });
   });
 
+  it("spl-picosol-prefund-swap-via-stake-into-marinade-use-bridge-vote", async () => {
+    await prefundSwapViaStakeFixturesTest(
+      1_000_000_000n,
+      {
+        inp: PICOSOL_TOKEN_ACC_NAME,
+        out: "signer-msol-token",
+      },
+      { useBridgeVote: true }
+    );
+  });
+
   it("spl-picosol-prefund-swap-via-stake-into-spl-bsol", async () => {
     await prefundSwapViaStakeFixturesTest(1_000_000_000n, {
       inp: PICOSOL_TOKEN_ACC_NAME,
       out: "signer-bsol-token",
     });
+  });
+
+  it("spl-picosol-prefund-swap-via-stake-into-spl-bsol-use-bridge-vote", async () => {
+    await prefundSwapViaStakeFixturesTest(
+      1_000_000_000n,
+      {
+        inp: PICOSOL_TOKEN_ACC_NAME,
+        out: "signer-bsol-token",
+      },
+      { useBridgeVote: true }
+    );
   });
 });

--- a/ts/tests/utils/test/prefund-swap-via-stake.ts
+++ b/ts/tests/utils/test/prefund-swap-via-stake.ts
@@ -12,10 +12,16 @@ import { simTokenSwapAssertQuoteMatches } from "./swap";
 // Assume bridge stake seed 0 is always unused
 const BRIDGE_STAKE_SEED = 0;
 
+interface PrefundSwapViaStakeFixturesTestOpts {
+  useBridgeVote: boolean;
+}
+
 export async function prefundSwapViaStakeFixturesTest(
   amt: bigint,
-  tokenAccFixtures: { inp: string; out: string }
+  tokenAccFixtures: { inp: string; out: string },
+  opts: PrefundSwapViaStakeFixturesTestOpts = { useBridgeVote: false }
 ) {
+  const { useBridgeVote } = opts;
   const { inp: inpTokenAccName, out: outTokenAccName } = tokenAccFixtures;
   const [
     { addr: inpTokenAcc, owner: inpTokenAccOwner, mint: inpMint },
@@ -43,6 +49,9 @@ export async function prefundSwapViaStakeFixturesTest(
     signer: inpTokenAccOwner,
     bridgeStakeSeed: BRIDGE_STAKE_SEED,
   };
+  if (useBridgeVote) {
+    params.bridgeVote = quote.bridge.vote;
+  }
   const ix = prefundSwapViaStakeIx(router, params);
 
   // TODO: replace this fn with a custom fn that further


### PR DESCRIPTION
Add more detail to the return type so that users can for e.g. calculate the percentage of the instant unstake flash loan fee, since that fee is in terms of SOL, and the bridge stake account is the only thing thats also guaranteed to be in terms of SOL since the input and output mints may not be SOL.

Also modify `prefundSwapViaStakeIx` to optionally take the vote account returned as arg, allowing it to skip redoing the quoting procedure to find a matching vote account. 