### PR TITLE
Take into account `MIN_ACTIVE_STAKE` for withdraw stake

### DIFF
--- a/core/src/routers/spl_stake_pool/withdraw_stake.rs
+++ b/core/src/routers/spl_stake_pool/withdraw_stake.rs
@@ -75,6 +75,8 @@ impl WithdrawStakeQuoter for SplWithdrawStakeQuoter<'_> {
                 current_epoch: self.curr_epoch,
             },
         )?;
+        // TODO: maybe need to handle edge case where no active stake
+        // i.e. users can withdraw from transient stake
         conv_quote(quote, vsi)
     }
 }
@@ -175,7 +177,7 @@ fn conv_quote(
     }: sanctum_spl_stake_pool_core::WithdrawStakeQuote,
     vsi: &ValidatorStakeInfo,
 ) -> Result<WithdrawStakeQuote, SplStakePoolError> {
-    if lamports_staked > vsi.active_stake_lamports() {
+    if lamports_staked > vsi.active_stake_lamports().saturating_sub(MIN_ACTIVE_STAKE) {
         // StakeWithdrawalTooLarge
         return Err(SplStakePoolError::StakeLamportsNotEqualToMinimum);
     }

--- a/ts/tests/test/spl.test.ts
+++ b/ts/tests/test/spl.test.ts
@@ -10,7 +10,10 @@ import {
   routerForSwaps,
   withdrawSolFixturesTest,
 } from "../utils";
-import { quoteWithdrawSol } from "@sanctumso/sanctum-router";
+import {
+  quotePrefundWithdrawStake,
+  quoteWithdrawSol,
+} from "@sanctumso/sanctum-router";
 
 const PICOSOL_TOKEN_ACC_NAME = "signer-picosol-token";
 
@@ -72,6 +75,25 @@ describe("SPL Test", async () => {
       750_000_000_000n,
       PICOSOL_TOKEN_ACC_NAME
     );
+  });
+
+  it("spl-picosol-quote-prefund-withdraw-stake-fails-when-amt-too-much", async () => {
+    const rpc = localRpc();
+    const router = await routerForSwaps(rpc, [
+      { swap: "prefundWithdrawStake", inp: PICOSOL_MINT },
+    ]);
+    const quoteFn = () =>
+      quotePrefundWithdrawStake(router, {
+        // picsol validator list fixtures:
+        // - vsi_active_lamports=210_425__790_541_328
+        // - mint_supply=108_350__525_083_404
+        // - total_lamports=128_350__525_083_404
+        // - stake_withdrawal_fee=0
+        // (yes i know the numbers dont add up, see test fixtures README)
+        amt: 177_636_552_503_991n,
+        inp: PICOSOL_MINT,
+      });
+    expect(quoteFn).toThrowError(/StakeLamportsNotEqualToMinimum/);
   });
 
   // PrefundSwapViaStake


### PR DESCRIPTION
Router was previously returning unserviceable quotes for routes that involve a SPL withdraw stake if the withdrawal results in the validator stake account falling below `MIN_ACTIVE_STAKE`. PR fixes this by checking for this limit properly. Also add regression test that is a withdraw stake quote that is supposed to fail right at the boundary of this limit. 